### PR TITLE
ability to deploy db-conn settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- ### Fixed
+
+### Added
+- Ability to deploy db-connection settings by adding `/database-connections/[connection-name]/settings.json`.
+
+### Fixed
 - Options reset on `databases` update issue. 
 
 ## [2.3.1] - 2018-11-29

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ repository =>
     some other resource server.json
   database-connections
     my-connection-name
+      settings.json
       get_user.js
       login.js
   rules-configs

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "auth0-extension-tools": "1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "auth0-oauth2-express": "^1.1.8",
-    "auth0-source-control-extension-tools": "3.0.10",
+    "auth0-source-control-extension-tools": "^3.0.10",
     "axios": "^0.15.0",
     "babel": "^6.5.2",
     "babel-core": "^6.9.1",

--- a/server/lib/common.js
+++ b/server/lib/common.js
@@ -77,6 +77,22 @@ const getDatabaseScriptDetails = (filename) => {
   return null;
 };
 
+const getDatabaseSettingsDetails = (filename) => {
+  if (config('TFS_TYPE') !== 'git') {
+    filename = filename.replace(`${config('TFS_PATH')}/`, '');
+  }
+
+  const parts = filename.split('/');
+  const length = parts.length;
+  if (length >= 3 && parts[length - 1] === 'settings.json') {
+    return {
+      database: parts[length - 2],
+      name: 'settings'
+    };
+  }
+  return null;
+};
+
 /*
  * Only Javascript and JSON files.
  */
@@ -100,8 +116,9 @@ const validFilesOnly = (fileName) => {
   } else if (isConfigurable(fileName, constants.RULES_CONFIGS_DIRECTORY)) {
     return /\.(js|json)$/i.test(fileName);
   } else if (isDatabaseConnection(fileName)) {
-    const script = getDatabaseScriptDetails(fileName);
-    return !!script;
+    const script = !!getDatabaseScriptDetails(fileName);
+    const settings = !!getDatabaseSettingsDetails(fileName);
+    return script || settings;
   }
 
   return false;
@@ -116,5 +133,6 @@ module.exports = {
   isEmailProvider,
   isConfigurable,
   getDatabaseScriptDetails,
+  getDatabaseSettingsDetails,
   validFilesOnly
 };

--- a/server/lib/common.js
+++ b/server/lib/common.js
@@ -3,6 +3,7 @@ import { getPersonalAccessTokenHandler, getBasicHandler, WebApi } from 'vso-node
 import { constants } from 'auth0-source-control-extension-tools';
 
 import config from './config';
+import _ from 'lodash';
 
 const getApi = () => {
   const apiType = config('TFS_TYPE') === 'git' ? 'getGitApi' : 'getTfvcApi';
@@ -124,6 +125,35 @@ const validFilesOnly = (fileName) => {
   return false;
 };
 
+const getDatabaseFiles = (files) => {
+  const databases = {};
+
+  _.filter(files, f => isDatabaseConnection(f.path)).forEach(file => {
+    const script = getDatabaseScriptDetails(file.path);
+    const settings = getDatabaseSettingsDetails(file.path);
+
+    if (script) {
+      databases[script.database] = databases[script.database] || [];
+      databases[script.database].push({
+        ...script,
+        id: file.id,
+        path: file.path
+      });
+    }
+
+    if (settings) {
+      databases[settings.database] = databases[settings.database] || [];
+      databases[settings.database].push({
+        ...settings,
+        id: file.id,
+        path: file.path
+      });
+    }
+  });
+
+  return databases;
+};
+
 module.exports = {
   getApi,
   getPrefix,
@@ -132,7 +162,6 @@ module.exports = {
   isTemplate,
   isEmailProvider,
   isConfigurable,
-  getDatabaseScriptDetails,
-  getDatabaseSettingsDetails,
+  getDatabaseFiles,
   validFilesOnly
 };

--- a/server/lib/tfs-git.js
+++ b/server/lib/tfs-git.js
@@ -277,30 +277,7 @@ const downloadDatabaseScript = (repositoryId, branch, databaseName, scripts) => 
  * Get all database scripts.
  */
 const getDatabaseData = (repositoryId, branch, files) => {
-  const databases = {};
-
-  _.filter(files, f => common.isDatabaseConnection(f.path)).forEach(file => {
-    const script = common.getDatabaseScriptDetails(file.path);
-    const settings = common.getDatabaseSettingsDetails(file.path);
-
-    if (script) {
-      databases[script.database] = databases[script.database] || [];
-      databases[script.database].push({
-        ...script,
-        id: file.id,
-        path: file.path
-      });
-    }
-
-    if (settings) {
-      databases[settings.database] = databases[settings.database] || [];
-      databases[settings.database].push({
-        ...settings,
-        id: file.id,
-        path: file.path
-      });
-    }
-  });
+  const databases = common.getDatabaseFiles(files);
 
   return Promise.map(Object.keys(databases), (databaseName) => downloadDatabaseScript(repositoryId, branch, databaseName, databases[databaseName]), { concurrency: 2 });
 };

--- a/server/lib/tfs-tfvc.js
+++ b/server/lib/tfs-tfvc.js
@@ -311,10 +311,14 @@ const downloadDatabaseScript = (changesetId, databaseName, scripts) => {
   scripts.forEach(script => {
     downloads.push(downloadFile(script, changesetId)
       .then(file => {
-        database.scripts.push({
-          name: script.name,
-          scriptFile: file.contents
-        });
+        if (script.name === 'settings') {
+          database.settings = file.contents;
+        } else {
+          database.scripts.push({
+            name: script.name,
+            scriptFile: file.contents
+          });
+        }
       })
     );
   });
@@ -326,15 +330,26 @@ const downloadDatabaseScript = (changesetId, databaseName, scripts) => {
 /*
  * Get all database scripts.
  */
-const getDatabaseScripts = (changesetId, files) => {
+const getDatabaseData = (changesetId, files) => {
   const databases = {};
 
   _.filter(files, f => common.isDatabaseConnection(f.path)).forEach(file => {
     const script = common.getDatabaseScriptDetails(file.path);
+    const settings = common.getDatabaseSettingsDetails(file.path);
+
     if (script) {
       databases[script.database] = databases[script.database] || [];
       databases[script.database].push({
         ...script,
+        id: file.id,
+        path: file.path
+      });
+    }
+
+    if (settings) {
+      databases[settings.database] = databases[settings.database] || [];
+      databases[settings.database].push({
+        ...settings,
         id: file.id,
         path: file.path
       });
@@ -420,7 +435,7 @@ export const getChanges = (project, changesetId) =>
 
         const promises = {
           rules: getRules(changesetId, files),
-          databases: getDatabaseScripts(changesetId, files),
+          databases: getDatabaseData(changesetId, files),
           emailProvider: getEmailProvider(changesetId, files),
           emailTemplates: getHtmlTemplates(changesetId, files, constants.EMAIL_TEMPLATES_DIRECTORY, constants.EMAIL_TEMPLATES_NAMES),
           pages: getHtmlTemplates(changesetId, files, constants.PAGES_DIRECTORY, constants.PAGE_NAMES),

--- a/server/lib/tfs-tfvc.js
+++ b/server/lib/tfs-tfvc.js
@@ -331,30 +331,7 @@ const downloadDatabaseScript = (changesetId, databaseName, scripts) => {
  * Get all database scripts.
  */
 const getDatabaseData = (changesetId, files) => {
-  const databases = {};
-
-  _.filter(files, f => common.isDatabaseConnection(f.path)).forEach(file => {
-    const script = common.getDatabaseScriptDetails(file.path);
-    const settings = common.getDatabaseSettingsDetails(file.path);
-
-    if (script) {
-      databases[script.database] = databases[script.database] || [];
-      databases[script.database].push({
-        ...script,
-        id: file.id,
-        path: file.path
-      });
-    }
-
-    if (settings) {
-      databases[settings.database] = databases[settings.database] || [];
-      databases[settings.database].push({
-        ...settings,
-        id: file.id,
-        path: file.path
-      });
-    }
-  });
+  const databases = common.getDatabaseFiles(files);
 
   return Promise.map(Object.keys(databases), (databaseName) => downloadDatabaseScript(changesetId, databaseName, databases[databaseName]), { concurrency: 2 });
 };

--- a/server/lib/unifyData.js
+++ b/server/lib/unifyData.js
@@ -55,10 +55,23 @@ const unifyItem = (item, type) => {
     }
 
     case 'databases': {
+      let settings = item.settings || {};
+      try {
+        settings = JSON.parse(item.settings);
+      } catch (e) {
+        logger.info(`Cannot parse settings of ${item.name} ${type}`);
+      }
       const customScripts = {};
+      const options = settings.options || {};
+
       _.forEach(item.scripts, (script) => { customScripts[script.name] = script.scriptFile; });
 
-      return ({ strategy: 'auth0', name: item.name, options: { customScripts, enabledDatabaseCustomization: true } });
+      if (item.scripts || item.scripts.length) {
+        options.customScripts = customScripts;
+        options.enabledDatabaseCustomization = true;
+      }
+
+      return ({ ...settings, options, strategy: 'auth0', name: item.name });
     }
 
     case 'resourceServers':
@@ -110,6 +123,6 @@ export default function (assets) {
       result[type] = unifyItem(data, type);
     }
   });
-console.log(result);
+
   return result;
 }


### PR DESCRIPTION
## ✏️ Changes
Added possibility to read `settings.json` of database connection. It should be placed at `/database-connections/[connection-name]/settings.json`, it can contain any connection settings, including `options`. Options will be merged with `customScripts`, if db-scripts are provided.
  
## 🔗 References
Slack: https://auth0.slack.com/archives/C9170558S/p1544222234120100
  
## 🎯 Testing
✅ This change has been tested locally
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  