### PR TITLE
ability to deploy db-conn settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- ### Fixed
+
+### Added
+- Ability to deploy db-connection settings by adding `/database-connections/[connection-name]/settings.json`.
+
+### Fixed
 - Options reset on `databases` update issue. 
 
 ## [2.3.1] - 2018-11-29

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ repository =>
     some other resource server.json
   database-connections
     my-connection-name
+      settings.json
       get_user.js
       login.js
   rules-configs

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "auth0-extension-tools": "1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "auth0-oauth2-express": "^1.1.8",
-    "auth0-source-control-extension-tools": "3.0.10",
+    "auth0-source-control-extension-tools": "^3.0.10",
     "axios": "^0.15.0",
     "babel": "^6.5.2",
     "babel-core": "^6.9.1",

--- a/server/lib/tfs-git.js
+++ b/server/lib/tfs-git.js
@@ -257,10 +257,14 @@ const downloadDatabaseScript = (repositoryId, branch, databaseName, scripts) => 
   scripts.forEach(script => {
     downloads.push(downloadFile(repositoryId, branch, script)
       .then(file => {
-        database.scripts.push({
-          name: script.name,
-          scriptFile: file.contents
-        });
+        if (script.name === 'settings') {
+          database.settings = file.contents;
+        } else {
+          database.scripts.push({
+            name: script.name,
+            scriptFile: file.contents
+          });
+        }
       })
     );
   });
@@ -272,20 +276,8 @@ const downloadDatabaseScript = (repositoryId, branch, databaseName, scripts) => 
 /*
  * Get all database scripts.
  */
-const getDatabaseScripts = (repositoryId, branch, files) => {
-  const databases = {};
-
-  _.filter(files, f => common.isDatabaseConnection(f.path)).forEach(file => {
-    const script = common.getDatabaseScriptDetails(file.path);
-    if (script) {
-      databases[script.database] = databases[script.database] || [];
-      databases[script.database].push({
-        ...script,
-        id: file.id,
-        path: file.path
-      });
-    }
-  });
+const getDatabaseData = (repositoryId, branch, files) => {
+  const databases = common.getDatabaseFiles(files);
 
   return Promise.map(Object.keys(databases), (databaseName) => downloadDatabaseScript(repositoryId, branch, databaseName, databases[databaseName]), { concurrency: 2 });
 };
@@ -366,7 +358,7 @@ export const getChanges = (repositoryId, branch) =>
 
         const promises = {
           rules: getRules(repositoryId, branch, files),
-          databases: getDatabaseScripts(repositoryId, branch, files),
+          databases: getDatabaseData(repositoryId, branch, files),
           emailProvider: getEmailProvider(repositoryId, branch, files),
           emailTemplates: getHtmlTemplates(repositoryId, branch, files, constants.EMAIL_TEMPLATES_DIRECTORY, constants.EMAIL_TEMPLATES_NAMES),
           pages: getHtmlTemplates(repositoryId, branch, files, constants.PAGES_DIRECTORY, constants.PAGE_NAMES),

--- a/server/lib/unifyData.js
+++ b/server/lib/unifyData.js
@@ -55,10 +55,23 @@ const unifyItem = (item, type) => {
     }
 
     case 'databases': {
+      let settings = item.settings || {};
+      try {
+        settings = JSON.parse(item.settings);
+      } catch (e) {
+        logger.info(`Cannot parse settings of ${item.name} ${type}`);
+      }
       const customScripts = {};
+      const options = settings.options || {};
+
       _.forEach(item.scripts, (script) => { customScripts[script.name] = script.scriptFile; });
 
-      return ({ strategy: 'auth0', name: item.name, options: { customScripts, enabledDatabaseCustomization: true } });
+      if (item.scripts || item.scripts.length) {
+        options.customScripts = customScripts;
+        options.enabledDatabaseCustomization = true;
+      }
+
+      return ({ ...settings, options, strategy: 'auth0', name: item.name });
     }
 
     case 'resourceServers':
@@ -110,6 +123,6 @@ export default function (assets) {
       result[type] = unifyItem(data, type);
     }
   });
-console.log(result);
+
   return result;
 }


### PR DESCRIPTION
## ✏️ Changes
Added possibility to read `settings.json` of database connection. It should be placed at `/database-connections/[connection-name]/settings.json`, it can contain any connection settings, including `options`. Options will be merged with `customScripts`, if db-scripts are provided.
  
## 🔗 References
Slack: https://auth0.slack.com/archives/C9170558S/p1544222234120100
  
## 🎯 Testing
✅ This change has been tested locally
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  